### PR TITLE
Match prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# No temp VIM files
+*.swp
+*.swo

--- a/match_prefix/match_prefix.rb
+++ b/match_prefix/match_prefix.rb
@@ -1,0 +1,53 @@
+require_relative 'trie_builder'
+
+class MatchPrefix
+  def initialize(words:)
+    @words = words
+    @root = build_trie
+  end
+
+  def process!(prefix:)
+    finder_node = match(prefix)
+    traverse_depth_first(finder_node, prefix)
+  end
+
+  private
+
+  attr_reader :words,
+              :root
+
+  def build_trie
+    TrieBuilder.new.build(words)
+  end
+
+  def match(prefix)
+    current_node = root
+
+    prefix.chars.each do |char|
+      if current_node.children.key?(char)
+        current_node = current_node.children[char]
+      else
+        return nil
+      end
+    end
+
+    current_node
+  end
+
+  def traverse_depth_first(node, prefix)
+    return [] if node.nil?
+    return [prefix] if node.children.keys.empty?
+
+    result = []
+
+    if node.is_end_of_word?
+      result << prefix
+    end
+
+    node.children.keys.each do |char|
+      result << traverse_depth_first(node.children[char], prefix + char)
+    end
+
+    result.flatten
+  end
+end

--- a/match_prefix/trie.rb
+++ b/match_prefix/trie.rb
@@ -1,0 +1,23 @@
+class Trie
+  attr_reader :data,
+              :children
+
+  def initialize
+    @data = ""
+    @children = {}
+    @end_of_word = false 
+  end
+
+  def add_child(character, node)
+    children.merge!(character => node)
+    children[character]
+  end
+
+  def is_end_of_word?
+    @end_of_word
+  end
+
+  def is_end_of_word
+    @end_of_word = true
+  end
+end

--- a/match_prefix/trie_builder.rb
+++ b/match_prefix/trie_builder.rb
@@ -1,0 +1,33 @@
+require_relative 'trie' 
+
+class TrieBuilder
+  attr_reader :root
+
+  def initialize
+    @root = Trie.new
+  end
+
+  def build(words)
+    words.each do |word|
+      add(word)
+    end
+
+    root
+  end
+
+  private
+
+  def add(word)
+    current_node = root
+
+    word.chars.each do |ch|
+      if current_node.children.key?(ch)
+        current_node = current_node.children[ch]
+      else
+        current_node = current_node.add_child(ch, Trie.new)
+      end
+    end
+
+    current_node.is_end_of_word
+  end
+end


### PR DESCRIPTION
Given a prefix and a list of words, find all words that start with given
prefix

- Use a trie that contains data, children and an end of word indicator
- Use a hash to implement the children where the key is a character and
  the value is a Trie
- Iterate through list of words and build the trie
- Use depth first search to traverse the trie using the prefix to find
  any matching words